### PR TITLE
FIX: delete a space causing a CF API error from the `dns_record` example

### DIFF
--- a/update-cloudflare-dns.conf
+++ b/update-cloudflare-dns.conf
@@ -4,7 +4,7 @@
 ## Internal interface will be chosen automaticly as a primary default interface
 what_ip="internal"
 ## DNS A record to be updated, you can separate multiple records by comma
-dns_record="ddns.example.com, ddns2.example.com"
+dns_record="ddns.example.com,ddns2.example.com"
 ## Cloudflare's Zone ID, you can find this on the landing/overview page of your domain.
 zoneid="ChangeMe"
 ## Cloudflare Zone API Token


### PR DESCRIPTION
The example `dns_record` variable has space between the records. But this causes the following error with the CF API: 

```{"success":false,"errors":[{"code":10000,"message":"PUT method not allowed for the api_token authentication scheme"}]}```

Removing the space between the records fixes the issue.