### PR TITLE
Add option to search for records by comment

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,8 @@ sudo mv update-cloudflare-dns.conf /usr/local/bin/update-cloudflare-dns.conf
 | zoneid                    | ChangeMe         | Cloudflare's [Zone ID](https://developers.cloudflare.com/fundamentals/get-started/basic-tasks/find-account-and-zone-ids/) |
 | proxied                   | false            | Use Cloudflare proxy on dns record true/false                                                                             |
 | ttl                       | 120              | 120-7200 in seconds or 1 for Auto                                                                                         |
+| lookup_by_tag             | false            | Look up the records by comment instead of name                                                |
+| tag                       | ChangeMe         | Which comment to search for            |
 
 ### Optional Notifications Parameters
 

--- a/update-cloudflare-dns.conf
+++ b/update-cloudflare-dns.conf
@@ -13,6 +13,10 @@ cloudflare_zone_api_token="ChangeMe"
 proxied="false"
 ## 120-7200 in seconds or 1 for Auto
 ttl=120
+## Search by comments instead of by name
+lookup_by_tag="true"
+## Comment to be searched for
+tag="ddns"
 
 ## Telegram Notifications yes/no (only sent if DNS is updated)
 notify_me_telegram="no"


### PR DESCRIPTION
With this change it is possible to first lookup the names of all records with a certain comment (e.g. "ddns") and then update the IP for those records; this way, it is not necessary to update de configuration file every time a new subdomain is added, as long as it shares the same comment.